### PR TITLE
feat: dependabot と auto merge CI を導入

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      timezone: "Asia/Tokyo"
+      time: "08:00"
+    target-branch: "main"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      timezone: "Asia/Tokyo"
+      time: "08:00"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,22 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## 概要

[newt239/next-template](https://github.com/newt239/next-template) を参考に、Dependabot による依存関係の自動更新と、Dependabot PR の auto-merge を導入します。

## 変更内容

- `.github/dependabot.yml` を追加
  - npm(pnpm 含む)を weekly(Asia/Tokyo 8:00)で更新、全依存を 1 グループに集約
  - GitHub Actions(SHA ピン留め)も weekly で更新
- `.github/workflows/dependabot-auto-merge.yml` を追加
  - Dependabot の PR に対して `gh pr merge --auto --merge` で auto-merge を有効化

## 関連するリポジトリ設定変更(API で実施)

- auto-merge の有効化(`allow_auto_merge: true`)
- main ブランチにルールセットを作成し、`codecheck` を必須ステータスチェックに設定(これがないと CI を待たず即マージされるため)

🤖 Generated with [Claude Code](https://claude.com/claude-code)